### PR TITLE
Add waitForElementVisible method

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,10 +24,10 @@ module.exports = function(grunt) {
 		}
 	});
 
-	// For this to work, you need to have run `npm install grunt-simple-mocha`
+	// test
 	grunt.loadNpmTasks('grunt-simple-mocha');
+	// lint
 	grunt.loadNpmTasks('grunt-contrib-jshint');
-	// Add a default task. This is optional, of course :)
+	// default task
 	grunt.registerTask('default', ['simplemocha', 'jshint']);
-	// Add a default task. This is optional, of course :)
 };

--- a/lib/drivex.js
+++ b/lib/drivex.js
@@ -91,6 +91,26 @@ DriveX.prototype = {
 		});
 	},
 	/**
+	 * Wait for timeout milliseconds for the WebElement to be visible
+	 * It may exist in the DOM at page load time, but when shown on-demand
+	 * there needs to be a wait before it's visible because of a fade-in or
+	 * something similar.
+	 * @param locator {LocatorJSON}
+	 * @param timeout {Number}
+	 * @param msg {String} optional message for any error messages
+	 * @returns {Promise} resolves to true or rejected
+	 */
+	waitForElementVisible: function (locator, timeout, msg) {
+		var that = this;
+		return this.driver.wait(function () {
+			return that.visible(locator);
+		}, timeout, msg).then(function(finalReturn) {
+			return finalReturn;
+		}, function(err) {
+			return false;
+		});
+	},
+	/**
 	 * determine if only one of the WebElements in the elements array is visible
 	 * @param elements {Array} array of WebElements
 	 * @returns {Promise} promise resolves to single visible element from "elements" or Error

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-drivex",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Selenium webdriver extensions for Nemo automation framework",
   "scripts": {
     "test": "grunt"


### PR DESCRIPTION
This is to avoid calls to `nemo.driver.sleep()` while animations or transitions are running and hopefully make tests more stable.